### PR TITLE
티켓 리스트 조회 기능 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ allprojects {
 object Versions {
     const val KTOR_CLIENT = "3.0.3"
     const val COROUTINES = "1.9.0"
+    const val SPRINGDOC = "2.7.0"
 }
 
 dependencies {
@@ -40,6 +41,9 @@ dependencies {
     // spring boot
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${Versions.SPRINGDOC}")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-api:${Versions.SPRINGDOC}")
+    implementation("org.springdoc:springdoc-openapi-starter-common:${Versions.SPRINGDOC}")
 
     // coroutine
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.COROUTINES}")

--- a/src/main/kotlin/com/srt/api/SrtController.kt
+++ b/src/main/kotlin/com/srt/api/SrtController.kt
@@ -1,10 +1,13 @@
 package com.srt.api
 
+import com.srt.api.vo.GetTicketListRequest
+import com.srt.api.vo.GetTicketListResponse
 import com.srt.api.vo.LoginRequest
 import com.srt.api.vo.LoginResponse
 import com.srt.configuration.LoginRequired
 import com.srt.configuration.TokenHolder
 import com.srt.service.SrtService
+import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
@@ -21,14 +24,18 @@ class SrtController(
     suspend fun login(@RequestBody loginRequest: LoginRequest): ResponseEntity<LoginResponse> {
         return ResponseEntity.ok(
             LoginResponse(
-                srtService.login(loginRequest.toAccount()),
+                srtService.login(loginRequest.toCommand()),
             ),
         )
     }
 
     @LoginRequired
     @GetMapping("/list")
-    fun list(tokenHolder: TokenHolder): String {
-        TODO()
+    suspend fun list(@ParameterObject request: GetTicketListRequest, tokenHolder: TokenHolder): ResponseEntity<GetTicketListResponse> {
+        return ResponseEntity.ok(
+            GetTicketListResponse(
+                srtService.list(request.toQuery(), tokenHolder),
+            ),
+        )
     }
 }

--- a/src/main/kotlin/com/srt/api/SrtController.kt
+++ b/src/main/kotlin/com/srt/api/SrtController.kt
@@ -3,10 +3,10 @@ package com.srt.api
 import com.srt.api.vo.GetTicketListRequest
 import com.srt.api.vo.GetTicketListResponse
 import com.srt.api.vo.LoginRequest
-import com.srt.api.vo.LoginResponse
+import com.srt.api.vo.SrtResponse
 import com.srt.configuration.LoginRequired
-import com.srt.configuration.TokenHolder
 import com.srt.service.SrtService
+import com.srt.service.vo.SrtSession
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -21,21 +21,24 @@ class SrtController(
     private val srtService: SrtService,
 ) {
     @PostMapping("/login")
-    suspend fun login(@RequestBody loginRequest: LoginRequest): ResponseEntity<LoginResponse> {
+    suspend fun login(@RequestBody loginRequest: LoginRequest): ResponseEntity<SrtResponse<Unit>> {
         return ResponseEntity.ok(
-            LoginResponse(
-                srtService.login(loginRequest.toCommand()),
+            SrtResponse.of(
+                token = srtService.login(loginRequest.toCommand()).token,
             ),
         )
     }
 
     @LoginRequired
     @GetMapping("/list")
-    suspend fun list(@ParameterObject request: GetTicketListRequest, tokenHolder: TokenHolder): ResponseEntity<GetTicketListResponse> {
-        return ResponseEntity.ok(
-            GetTicketListResponse(
-                srtService.list(request.toQuery(), tokenHolder),
-            ),
-        )
+    suspend fun list(@ParameterObject request: GetTicketListRequest, session: SrtSession): ResponseEntity<SrtResponse<List<GetTicketListResponse>>> {
+        return srtService.list(request.toQuery(), session).let { (token, tickets) ->
+            ResponseEntity.ok(
+                SrtResponse.of(
+                    token = token.token,
+                    data = tickets.map { GetTicketListResponse.of(it) },
+                ),
+            )
+        }
     }
 }

--- a/src/main/kotlin/com/srt/api/vo/GetTicketListRequest.kt
+++ b/src/main/kotlin/com/srt/api/vo/GetTicketListRequest.kt
@@ -1,7 +1,7 @@
 package com.srt.api.vo
 
-import com.srt.code.StationCodes
 import com.srt.service.vo.GetTicketListQuery
+import com.srt.share.code.StationCodes
 
 data class GetTicketListRequest(
     val departureDate: String,

--- a/src/main/kotlin/com/srt/api/vo/GetTicketListRequest.kt
+++ b/src/main/kotlin/com/srt/api/vo/GetTicketListRequest.kt
@@ -1,0 +1,26 @@
+package com.srt.api.vo
+
+import com.srt.code.StationCodes
+import com.srt.service.vo.GetTicketListQuery
+
+data class GetTicketListRequest(
+    val departureDate: String,
+    val departureTime: String,
+    val departureStationCode: String,
+    val arrivalStationCode: String,
+    val passengerNumber: Int = 1,
+) {
+    init {
+        // TODO: validate
+    }
+
+    fun toQuery(): GetTicketListQuery {
+        return GetTicketListQuery(
+            departureDate = departureDate,
+            departureTime = departureTime,
+            departureStationCode = StationCodes.fromCode(departureStationCode),
+            arrivalStationCode = StationCodes.fromCode(arrivalStationCode),
+            passengerNumber = passengerNumber,
+        )
+    }
+}

--- a/src/main/kotlin/com/srt/api/vo/GetTicketListResponse.kt
+++ b/src/main/kotlin/com/srt/api/vo/GetTicketListResponse.kt
@@ -1,5 +1,25 @@
 package com.srt.api.vo
 
+import com.srt.service.vo.Ticket
+
 data class GetTicketListResponse(
-    val tickets: List<String>,
-)
+    val trainNumber: String,
+    val departureDate: String,
+    val departureTime: String,
+    val arrivalDate: String,
+    val arrivalTime: String,
+    val canReserve: Boolean,
+) {
+    companion object {
+        fun of(ticket: Ticket): GetTicketListResponse {
+            return GetTicketListResponse(
+                trainNumber = ticket.trainNumber,
+                departureDate = ticket.departureDate,
+                departureTime = ticket.departureTime,
+                arrivalDate = ticket.arrivalDate,
+                arrivalTime = ticket.arrivalTime,
+                canReserve = ticket.canReserve,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/srt/api/vo/GetTicketListResponse.kt
+++ b/src/main/kotlin/com/srt/api/vo/GetTicketListResponse.kt
@@ -1,0 +1,5 @@
+package com.srt.api.vo
+
+data class GetTicketListResponse(
+    val tickets: List<String>,
+)

--- a/src/main/kotlin/com/srt/api/vo/LoginRequest.kt
+++ b/src/main/kotlin/com/srt/api/vo/LoginRequest.kt
@@ -1,13 +1,13 @@
 package com.srt.api.vo
 
-import com.srt.service.vo.Account
+import com.srt.service.vo.LoginCommand
 
 data class LoginRequest(
     val id: String,
     val password: String,
 ) {
-    fun toAccount(): Account {
-        return Account(
+    fun toCommand(): LoginCommand {
+        return LoginCommand(
             id = id,
             password = password,
         )

--- a/src/main/kotlin/com/srt/api/vo/LoginResponse.kt
+++ b/src/main/kotlin/com/srt/api/vo/LoginResponse.kt
@@ -1,5 +1,0 @@
-package com.srt.api.vo
-
-data class LoginResponse(
-    val token: String,
-)

--- a/src/main/kotlin/com/srt/api/vo/SrtResponse.kt
+++ b/src/main/kotlin/com/srt/api/vo/SrtResponse.kt
@@ -1,0 +1,24 @@
+package com.srt.api.vo
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SrtResponse<T>(
+    val token: String,
+    val data: T? = null,
+) {
+    companion object {
+        fun <T> of(token: String, data: T): SrtResponse<T> {
+            return SrtResponse(
+                token = token,
+                data = data,
+            )
+        }
+
+        fun of(token: String): SrtResponse<Unit> {
+            return SrtResponse(
+                token = token,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/srt/client/SrtClient.kt
+++ b/src/main/kotlin/com/srt/client/SrtClient.kt
@@ -1,8 +1,11 @@
 package com.srt.client
 
 import com.srt.client.vo.GetNetFunnelKeyRequest
+import com.srt.client.vo.GetTicketListRequest
 import com.srt.client.vo.LoginRequest
 import com.srt.client.vo.LoginResponse
+import com.srt.code.StationCodes
+import com.srt.configuration.TokenHolder
 import com.srt.util.toFormUrlEncodedString
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -45,6 +48,55 @@ class SrtClient(
             Regex("key=(.+?)&").find(it)?.groupValues?.get(1)
                 ?: throw RuntimeException("NetFunnelKey를 가져올 수 없습니다.")
         }
+    }
+
+    suspend fun getTicketList(
+        departureDate: String,
+        departureTime: String,
+        departureStationCode: StationCodes,
+        arrivalStationCode: StationCodes,
+        passengerNumber: Int,
+        tokenHolder: TokenHolder,
+    ): List<String> {
+        // TODO: 정상적인 경로로 접근 부탁드립니다. 오류 발생함, netFunnelKey, JSESSIONID_ETK 외 추가적으로 필요한 정보가 있음
+        return httpClient.post("$BASE_URL/ara/selectListAra10007_n.do") {
+            setDefaultUserAgent()
+            contentType(ContentType.Application.FormUrlEncoded)
+            accept(ContentType.Application.Json)
+            cookie("JSESSIONID_ETK", tokenHolder.sessionId)
+            setBody(
+                GetTicketListRequest.create(
+                    departureDate = departureDate,
+                    departureTime = departureTime,
+                    departureStationCode = departureStationCode,
+                    arrivalStationCode = arrivalStationCode,
+                    passengerNumber = passengerNumber,
+                    netFunnelKey = tokenHolder.netFunnelKey,
+                ).toFormUrlEncodedString(),
+            )
+        }.body<String>().let {
+            println(it)
+            emptyList<String>()
+        }
+//        return httpClient.post("$BASE_URL/ara/selectListAra10007_n.do") {
+//            setDefaultUserAgent()
+//            contentType(ContentType.Application.FormUrlEncoded)
+//            accept(ContentType.Application.Json)
+//            cookie("JSESSIONID_ETK", tokenHolder.sessionId)
+//            setBody(GetTicketListRequest.create(
+//                departureDate = departureDate,
+//                departureTime = departureTime,
+//                departureStationCode = departureStationCode,
+//                arrivalStationCode = arrivalStationCode,
+//                passengerNumber = passengerNumber,
+//                netFunnelKey = tokenHolder.netFunnelKey,
+//            ).toFormUrlEncodedString())
+//        }.body<GetTicketListResponse>().let {
+//            if (it.isSuccess.not()) {
+//                throw RuntimeException("티켓 목록을 가져올 수 없습니다.")
+//            }
+//            it.tickets
+//        }
     }
 
     private fun HttpMessageBuilder.setDefaultUserAgent(): HttpMessageBuilder {

--- a/src/main/kotlin/com/srt/client/SrtClient.kt
+++ b/src/main/kotlin/com/srt/client/SrtClient.kt
@@ -21,12 +21,15 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpMessageBuilder
 import io.ktor.http.contentType
 import io.ktor.http.userAgent
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
 @Component
 class SrtClient(
     private val httpClient: HttpClient,
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     suspend fun login(id: String, password: String): SrtSession {
         return httpClient.requestPost<String>("$BASE_URL/apb/selectListApb01080_n.do") {
             setDefaultUserAgent()
@@ -85,6 +88,9 @@ class SrtClient(
         }.also {
             if (it.body.isSuccess.not()) {
                 throw RuntimeException("티켓 목록을 가져올 수 없습니다.")
+            }
+            if (it.cookies.isNotEmpty()) {
+                log.warn("티켓 목록 조회 시 쿠키가 반환되었습니다. - ${it.cookies}")
             }
         }.let {
             val sessionId = SessionId((it.cookies.findByName("JSESSIONID_XEBEC")?.value ?: session.sessionId))

--- a/src/main/kotlin/com/srt/client/SrtClient.kt
+++ b/src/main/kotlin/com/srt/client/SrtClient.kt
@@ -2,16 +2,20 @@ package com.srt.client
 
 import com.srt.client.vo.GetNetFunnelKeyRequest
 import com.srt.client.vo.GetTicketListRequest
+import com.srt.client.vo.GetTicketListResponse
 import com.srt.client.vo.LoginRequest
-import com.srt.client.vo.LoginResponse
-import com.srt.code.StationCodes
-import com.srt.configuration.TokenHolder
+import com.srt.service.vo.SrtSession
+import com.srt.service.vo.Ticket
+import com.srt.share.code.StationCodes
+import com.srt.share.value.NetFunnelKey
+import com.srt.share.value.SessionId
+import com.srt.util.findByName
+import com.srt.util.getByName
+import com.srt.util.requestPost
 import com.srt.util.toFormUrlEncodedString
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.request.accept
 import io.ktor.client.request.cookie
-import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.HttpMessageBuilder
@@ -23,30 +27,35 @@ import org.springframework.stereotype.Component
 class SrtClient(
     private val httpClient: HttpClient,
 ) {
-    suspend fun login(id: String, password: String): SessionKey {
-        return httpClient.post("$BASE_URL/apb/selectListApb01080_n.do") {
+    suspend fun login(id: String, password: String): SrtSession {
+        return httpClient.requestPost<String>("$BASE_URL/apb/selectListApb01080_n.do") {
             setDefaultUserAgent()
             contentType(ContentType.Application.FormUrlEncoded)
             accept(ContentType.Application.Json)
             setBody(LoginRequest.create(id, password).toFormUrlEncodedString())
-        }.body<LoginResponse>().let {
-            if (it.success.not()) {
-                throw RuntimeException("로그인에 실패했습니다. ${it.userMap["MSG"]}")
+        }.also {
+            if (it.cookies.size < 4) {
+                throw RuntimeException("로그인에 실패했습니다. 쿠키를 가져올 수 없습니다.")
             }
-            it.sessionId
+        }.cookies.let { cookies ->
+            SrtSession(
+                sessionId = cookies.getByName("JSESSIONID_XEBEC").value,
+                wmonid = cookies.getByName("WMONID").value,
+                srail_type10 = cookies.getByName("srail_type10", { it.value != "NULL" }).value,
+                srail_type8 = cookies.getByName("srail_type8", { it.value != "Y" }).value,
+            )
         }
     }
 
-    suspend fun getNetFunnelKey(key: SessionKey): NetFunnelKey {
-        return httpClient.post("https://nf.letskorail.com/ts.wseq") {
+    suspend fun getNetFunnelKey(sessionId: String): NetFunnelKey {
+        return httpClient.requestPost<String>("https://nf.letskorail.com/ts.wseq") {
             setDefaultUserAgent()
             contentType(ContentType.Application.FormUrlEncoded)
             accept(ContentType.Application.FormUrlEncoded)
-            cookie("JSESSIONID_ETK", key)
+            cookie("JSESSIONID_ETK", sessionId)
             setBody(GetNetFunnelKeyRequest().toFormUrlEncodedString())
-        }.body<String>().let {
-            Regex("key=(.+?)&").find(it)?.groupValues?.get(1)
-                ?: throw RuntimeException("NetFunnelKey를 가져올 수 없습니다.")
+        }.let {
+            extractNetFunnelKeyOrThrows(it.body)
         }
     }
 
@@ -56,14 +65,13 @@ class SrtClient(
         departureStationCode: StationCodes,
         arrivalStationCode: StationCodes,
         passengerNumber: Int,
-        tokenHolder: TokenHolder,
-    ): List<String> {
-        // TODO: 정상적인 경로로 접근 부탁드립니다. 오류 발생함, netFunnelKey, JSESSIONID_ETK 외 추가적으로 필요한 정보가 있음
-        return httpClient.post("$BASE_URL/ara/selectListAra10007_n.do") {
+        session: SrtSession,
+    ): Pair<SessionId, List<Ticket>> {
+        return httpClient.requestPost<GetTicketListResponse>("$BASE_URL/ara/selectListAra10007_n.do") {
             setDefaultUserAgent()
+            setAuthenticationCookies(session)
             contentType(ContentType.Application.FormUrlEncoded)
             accept(ContentType.Application.Json)
-            cookie("JSESSIONID_ETK", tokenHolder.sessionId)
             setBody(
                 GetTicketListRequest.create(
                     departureDate = departureDate,
@@ -71,32 +79,25 @@ class SrtClient(
                     departureStationCode = departureStationCode,
                     arrivalStationCode = arrivalStationCode,
                     passengerNumber = passengerNumber,
-                    netFunnelKey = tokenHolder.netFunnelKey,
+                    netFunnelKey = session.netFunnelKey!!,
                 ).toFormUrlEncodedString(),
             )
-        }.body<String>().let {
-            println(it)
-            emptyList<String>()
+        }.also {
+            if (it.body.isSuccess.not()) {
+                throw RuntimeException("티켓 목록을 가져올 수 없습니다.")
+            }
+        }.let {
+            val sessionId = SessionId((it.cookies.findByName("JSESSIONID_XEBEC")?.value ?: session.sessionId))
+            val tickets = it.body.trainListMap.map { it.toTicket() }
+
+            sessionId to tickets
         }
-//        return httpClient.post("$BASE_URL/ara/selectListAra10007_n.do") {
-//            setDefaultUserAgent()
-//            contentType(ContentType.Application.FormUrlEncoded)
-//            accept(ContentType.Application.Json)
-//            cookie("JSESSIONID_ETK", tokenHolder.sessionId)
-//            setBody(GetTicketListRequest.create(
-//                departureDate = departureDate,
-//                departureTime = departureTime,
-//                departureStationCode = departureStationCode,
-//                arrivalStationCode = arrivalStationCode,
-//                passengerNumber = passengerNumber,
-//                netFunnelKey = tokenHolder.netFunnelKey,
-//            ).toFormUrlEncodedString())
-//        }.body<GetTicketListResponse>().let {
-//            if (it.isSuccess.not()) {
-//                throw RuntimeException("티켓 목록을 가져올 수 없습니다.")
-//            }
-//            it.tickets
-//        }
+    }
+
+    private fun extractNetFunnelKeyOrThrows(body: String): NetFunnelKey {
+        return Regex("key=(.+?)&").find(body)?.groupValues?.get(1)?.let {
+            NetFunnelKey(it)
+        } ?: throw RuntimeException("NetFunnelKey를 가져올 수 없습니다.")
     }
 
     private fun HttpMessageBuilder.setDefaultUserAgent(): HttpMessageBuilder {
@@ -104,10 +105,15 @@ class SrtClient(
         return this
     }
 
+    private fun HttpMessageBuilder.setAuthenticationCookies(session: SrtSession): HttpMessageBuilder {
+        cookie("JSESSIONID_XEBEC", session.sessionId)
+        cookie("WMONID", session.wmonid)
+        cookie("srail_type10", session.srail_type10)
+        cookie("srail_type8", session.srail_type8)
+        return this
+    }
+
     companion object {
         const val BASE_URL = "https://app.srail.or.kr"
     }
 }
-
-typealias SessionKey = String
-typealias NetFunnelKey = String

--- a/src/main/kotlin/com/srt/client/vo/GetTicketListRequest.kt
+++ b/src/main/kotlin/com/srt/client/vo/GetTicketListRequest.kt
@@ -1,7 +1,7 @@
 package com.srt.client.vo
 
-import com.srt.code.SeatType
-import com.srt.code.StationCodes
+import com.srt.share.code.SeatType
+import com.srt.share.code.StationCodes
 
 internal data class GetTicketListRequest(
     val chtnDvCd: String = "1",

--- a/src/main/kotlin/com/srt/client/vo/GetTicketListRequest.kt
+++ b/src/main/kotlin/com/srt/client/vo/GetTicketListRequest.kt
@@ -1,0 +1,45 @@
+package com.srt.client.vo
+
+import com.srt.code.SeatType
+import com.srt.code.StationCodes
+
+internal data class GetTicketListRequest(
+    val chtnDvCd: String = "1",
+    val dptDt: String,
+    val dptTm: String,
+    val dptRsStnCd: String,
+    val arvRsStnCd: String,
+    val stlbTrnClsfCd: String = "05",
+    val trnGpCd: String = "109",
+    val psgNum: Int = 1,
+    val seatAttCd: String = SeatType.GENERAL.code,
+    val netfunnelKey: String,
+) {
+    init {
+//        require(dptDt.length == 8) { "Invalid departure date: $dptDt" }
+//        require(dptTm.length == 6) { "Invalid departure time: $dptTm" }
+        // TODO: dptDt: yyyyMMdd
+        // TODO: dptTm: HHmm00
+        // TODO: psgNum >= 1
+    }
+
+    companion object {
+        fun create(
+            departureDate: String,
+            departureTime: String,
+            departureStationCode: StationCodes,
+            arrivalStationCode: StationCodes,
+            passengerNumber: Int,
+            netFunnelKey: String,
+        ): GetTicketListRequest {
+            return GetTicketListRequest(
+                dptDt = departureDate,
+                dptTm = departureTime,
+                dptRsStnCd = departureStationCode.code,
+                arvRsStnCd = arrivalStationCode.code,
+                psgNum = passengerNumber,
+                netfunnelKey = netFunnelKey,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/srt/client/vo/GetTicketListResponse.kt
+++ b/src/main/kotlin/com/srt/client/vo/GetTicketListResponse.kt
@@ -1,38 +1,84 @@
 package com.srt.client.vo
 
+import com.srt.service.vo.Ticket
 import kotlinx.serialization.Serializable
 
-// TODO
 @Serializable
 internal data class GetTicketListResponse(
     val resultMap: List<GetTicketListResultMapResponse>,
+    val trainListMap: List<GetTicketListTrainListResponse>,
 ) {
     val isSuccess: Boolean
         get() = resultMap.isNotEmpty() && resultMap.first().strResult == "SUCC"
-
-    val tickets: List<String>
-        get() = resultMap.first().trainListMap.map { it.seatNo }
 }
 
 @Serializable
 internal data class GetTicketListResultMapResponse(
     val strResult: String,
-    val trainListMap: List<GetTicketListTrainListMapResponse>,
 )
 
 @Serializable
-internal data class GetTicketListTrainListMapResponse(
-    val rcvdAmt: Long,
-    val scarNo: Long,
-    val seatPrc: Long,
-    val psrmClCd: String,
-    val rqSeatAttCd: String,
-    val JRNYLIST_KEY: Long,
-    val psgTpCd: String,
-    val SEATLIST_KEY: Long,
-    val seatNo: String,
-    val psgTpDvCd: String,
-    val dcntKndCd: String,
-    val dcntAmt: Long,
-    val seatFare: Long,
-)
+internal data class GetTicketListTrainListResponse(
+    val etcRsvPsbCdNm: String,
+    val rcvdAmt: String,
+    val sprmRsvPsbStr: String,
+    val trnOrdrNo: Long,
+    val gnrmRsvPsbStr: String,
+    val gnrmRsvPsbColor: String,
+    val runTm: String,
+    val sprmRsvPsbColor: String,
+    val arvTm: String,
+    val fresRsvPsbCdNm: String? = null,
+    val runDt: String,
+    val stlbDturDvCd: String,
+    val ocurDlayTnum: Long,
+    val dlaySaleFlg: String,
+    val seatAttCd: String,
+    val rcvdFare: String,
+    val arvStnConsOrdr: String,
+    val sprmRsvPsbImg: String,
+    val rsvWaitPsbCdNm: String,
+    val chtnDvCd: String,
+    val rsvWaitPsbCd: String,
+    val seatSelect: String,
+    val dptStnRunOrdr: String,
+    val stlbTrnClsfCd: String,
+    val trainDiscGenRt: String,
+    val dptTm: String,
+    val stmpRsvPsbFlgCd: String,
+    val trnNstpLeadInfo: String,
+    val arvDt: String,
+    val gnrmRsvPsbCdNm: String,
+    val gnrmRsvPsbImg: String,
+    val trnGpCd: String,
+    val sprmRsvPsbCdNm: String,
+    val payTable: String,
+    val dptRsStnCd: String,
+    val ymsAplFlg: String,
+    val fresOprCno: Long,
+    val doReserv: String,
+    val timeTable: String,
+    val stndRsvPsbCdNm: String,
+    val dptStnConsOrdr: String,
+    val arvRsStnCd: String,
+    val dptDt: String,
+    val trnNo: String,
+    val arvStnRunOrdr: String,
+    val expnDptDlayTnum: String,
+    val trnCpsCd1: String,
+    val trnCpsCd2: String?,
+    val trnCpsCd3: String,
+    val trnCpsCd4: String,
+    val trnCpsCd5: String,
+) {
+    fun toTicket(): Ticket {
+        return Ticket(
+            trainNumber = trnNo,
+            departureDate = dptDt,
+            departureTime = dptTm,
+            arrivalDate = arvDt,
+            arrivalTime = arvTm,
+            canReserve = (sprmRsvPsbStr == "예약가능"),
+        )
+    }
+}

--- a/src/main/kotlin/com/srt/client/vo/GetTicketListResponse.kt
+++ b/src/main/kotlin/com/srt/client/vo/GetTicketListResponse.kt
@@ -1,0 +1,38 @@
+package com.srt.client.vo
+
+import kotlinx.serialization.Serializable
+
+// TODO
+@Serializable
+internal data class GetTicketListResponse(
+    val resultMap: List<GetTicketListResultMapResponse>,
+) {
+    val isSuccess: Boolean
+        get() = resultMap.isNotEmpty() && resultMap.first().strResult == "SUCC"
+
+    val tickets: List<String>
+        get() = resultMap.first().trainListMap.map { it.seatNo }
+}
+
+@Serializable
+internal data class GetTicketListResultMapResponse(
+    val strResult: String,
+    val trainListMap: List<GetTicketListTrainListMapResponse>,
+)
+
+@Serializable
+internal data class GetTicketListTrainListMapResponse(
+    val rcvdAmt: Long,
+    val scarNo: Long,
+    val seatPrc: Long,
+    val psrmClCd: String,
+    val rqSeatAttCd: String,
+    val JRNYLIST_KEY: Long,
+    val psgTpCd: String,
+    val SEATLIST_KEY: Long,
+    val seatNo: String,
+    val psgTpDvCd: String,
+    val dcntKndCd: String,
+    val dcntAmt: Long,
+    val seatFare: Long,
+)

--- a/src/main/kotlin/com/srt/client/vo/LoginRequest.kt
+++ b/src/main/kotlin/com/srt/client/vo/LoginRequest.kt
@@ -1,12 +1,14 @@
 package com.srt.client.vo
 
 internal data class LoginRequest(
-    val rsvTpCd: String = "",
-    val goUrl: String = "",
-    val from: String = "",
     val srchDvCd: String = "1",
     val srchDvNm: String,
+    val check: String = "Y",
+    val auto: String = "Y",
+    val login_referer: String = "https%3A%2F%2Fapp.srail.or.kr%2Fara%2Fara0101v.do",
     val hmpgPwdCphd: String,
+    val page: String = "menu",
+    val customerYn: String = "",
 ) {
     companion object {
         fun create(id: String, password: String): LoginRequest {

--- a/src/main/kotlin/com/srt/client/vo/LoginResponse.kt
+++ b/src/main/kotlin/com/srt/client/vo/LoginResponse.kt
@@ -2,7 +2,6 @@ package com.srt.client.vo
 
 import kotlinx.serialization.Serializable
 
-// TODO: 더 많은 필드들 존재, 로그인 성공 판단을 위한 값 확인 필요
 @Serializable
 internal data class LoginResponse(
     val userMap: Map<String, String>,
@@ -11,6 +10,15 @@ internal data class LoginResponse(
         get() = userMap["MSG"] == "정상적으로 로그인되었습니다."
 
     val sessionId: String
+        get() {
+            return userMap["KR_JSESSIONID"]?.let {
+                Regex("^JSESSIONID=(.+);Path=/$").find(it)
+            }?.let {
+                it.groupValues[1]
+            } ?: throw RuntimeException("세션 정보를 가져올 수 없습니다.")
+        }
+
+    val wmonid: String
         get() {
             return userMap["KR_JSESSIONID"]?.let {
                 Regex("^JSESSIONID=(.+);Path=/$").find(it)

--- a/src/main/kotlin/com/srt/code/SeatType.kt
+++ b/src/main/kotlin/com/srt/code/SeatType.kt
@@ -1,0 +1,7 @@
+package com.srt.code
+
+enum class SeatType(val description: String, val code: String) {
+    GENERAL("일반", "015"),
+    WHEEL_CHAIR("휠체어", "021"),
+    ELECTRIC_WHEEL_CHAIR("전동휠체어", "028"),
+}

--- a/src/main/kotlin/com/srt/code/StationCodes.kt
+++ b/src/main/kotlin/com/srt/code/StationCodes.kt
@@ -1,0 +1,15 @@
+package com.srt.code
+
+enum class StationCodes(val description: String, val code: String) {
+    STATION_CODE_0551("수서", "0551"),
+    STATION_CODE_0015("동대구", "0015"),
+    STATION_CODE_0552("동탄", "0552"),
+    ;
+
+    companion object {
+        fun fromCode(code: String): StationCodes {
+            return entries.firstOrNull { it.code == code }
+                ?: throw IllegalArgumentException("Invalid code: $code")
+        }
+    }
+}

--- a/src/main/kotlin/com/srt/configuration/KtorClientConfiguration.kt
+++ b/src/main/kotlin/com/srt/configuration/KtorClientConfiguration.kt
@@ -18,6 +18,7 @@ class KtorClientConfiguration {
                     Json {
                         ignoreUnknownKeys = true
                         isLenient = true
+                        encodeDefaults = false
                     },
                 )
             }

--- a/src/main/kotlin/com/srt/configuration/TokenArgumentResolver.kt
+++ b/src/main/kotlin/com/srt/configuration/TokenArgumentResolver.kt
@@ -1,6 +1,7 @@
 package com.srt.configuration
 
-import com.srt.configuration.TokenAttribute.TOKEN_ATTRIBUTE_NAME
+import com.srt.configuration.TokenAttribute.SRT_SESSION_KEY_ATTRIBUTE_NAME
+import com.srt.service.vo.SrtSession
 import org.springframework.core.MethodParameter
 import org.springframework.web.bind.support.WebDataBinderFactory
 import org.springframework.web.context.request.NativeWebRequest
@@ -10,7 +11,7 @@ import org.springframework.web.method.support.ModelAndViewContainer
 
 class TokenArgumentResolver : HandlerMethodArgumentResolver {
     override fun supportsParameter(parameter: MethodParameter): Boolean {
-        return TokenHolder::class.java.isAssignableFrom(parameter.parameterType)
+        return SrtSession::class.java.isAssignableFrom(parameter.parameterType)
     }
 
     override fun resolveArgument(
@@ -22,7 +23,7 @@ class TokenArgumentResolver : HandlerMethodArgumentResolver {
         return webRequest.getTokenFromAttribute()
     }
 
-    private fun NativeWebRequest.getTokenFromAttribute(): TokenHolder {
-        return this.getAttribute(TOKEN_ATTRIBUTE_NAME, RequestAttributes.SCOPE_REQUEST) as TokenHolder
+    private fun NativeWebRequest.getTokenFromAttribute(): SrtSession {
+        return this.getAttribute(SRT_SESSION_KEY_ATTRIBUTE_NAME, RequestAttributes.SCOPE_REQUEST) as SrtSession
     }
 }

--- a/src/main/kotlin/com/srt/configuration/TokenAttribute.kt
+++ b/src/main/kotlin/com/srt/configuration/TokenAttribute.kt
@@ -2,6 +2,6 @@ package com.srt.configuration
 
 object TokenAttribute {
     const val AUTHORIZATION_HEADER = "Authorization"
-    const val AUTHORIZATION_HEADER_PREFIX = "Bearer" + " "
-    const val TOKEN_ATTRIBUTE_NAME = "token"
+    const val AUTHORIZATION_HEADER_PREFIX = "Bearer "
+    const val SRT_SESSION_KEY_ATTRIBUTE_NAME = "session"
 }

--- a/src/main/kotlin/com/srt/configuration/TokenHolder.kt
+++ b/src/main/kotlin/com/srt/configuration/TokenHolder.kt
@@ -1,7 +1,0 @@
-package com.srt.configuration
-
-data class TokenHolder(
-    val token: String,
-    val sessionId: String,
-    val netFunnelKey: String,
-)

--- a/src/main/kotlin/com/srt/service/SrtService.kt
+++ b/src/main/kotlin/com/srt/service/SrtService.kt
@@ -1,7 +1,9 @@
 package com.srt.service
 
 import com.srt.client.SrtClient
-import com.srt.service.vo.Account
+import com.srt.configuration.TokenHolder
+import com.srt.service.vo.GetTicketListQuery
+import com.srt.service.vo.LoginCommand
 import com.srt.service.vo.SrtSessionKey
 import org.springframework.stereotype.Service
 
@@ -10,8 +12,8 @@ class SrtService(
     private val jwtProvider: JwtProvider,
     private val srtClient: SrtClient,
 ) {
-    suspend fun login(account: Account): String {
-        val sessionId = srtClient.login(account.id, account.password)
+    suspend fun login(loginCommand: LoginCommand): String {
+        val sessionId = srtClient.login(loginCommand.id, loginCommand.password)
         val netFunnelKey = srtClient.getNetFunnelKey(sessionId)
         val srtSessionKey = SrtSessionKey(
             sessionId = sessionId,
@@ -19,5 +21,16 @@ class SrtService(
         )
 
         return jwtProvider.createToken(srtSessionKey)
+    }
+
+    suspend fun list(getTicketListQuery: GetTicketListQuery, tokenHolder: TokenHolder): List<String> {
+        return srtClient.getTicketList(
+            departureDate = getTicketListQuery.departureDate,
+            departureTime = getTicketListQuery.departureTime,
+            departureStationCode = getTicketListQuery.departureStationCode,
+            arrivalStationCode = getTicketListQuery.arrivalStationCode,
+            passengerNumber = getTicketListQuery.passengerNumber,
+            tokenHolder = tokenHolder,
+        )
     }
 }

--- a/src/main/kotlin/com/srt/service/vo/GetTicketListQuery.kt
+++ b/src/main/kotlin/com/srt/service/vo/GetTicketListQuery.kt
@@ -1,6 +1,6 @@
 package com.srt.service.vo
 
-import com.srt.code.StationCodes
+import com.srt.share.code.StationCodes
 
 data class GetTicketListQuery(
     val departureDate: String,

--- a/src/main/kotlin/com/srt/service/vo/GetTicketListQuery.kt
+++ b/src/main/kotlin/com/srt/service/vo/GetTicketListQuery.kt
@@ -1,0 +1,11 @@
+package com.srt.service.vo
+
+import com.srt.code.StationCodes
+
+data class GetTicketListQuery(
+    val departureDate: String,
+    val departureTime: String,
+    val departureStationCode: StationCodes,
+    val arrivalStationCode: StationCodes,
+    val passengerNumber: Int,
+)

--- a/src/main/kotlin/com/srt/service/vo/LoginCommand.kt
+++ b/src/main/kotlin/com/srt/service/vo/LoginCommand.kt
@@ -1,6 +1,6 @@
 package com.srt.service.vo
 
-data class Account(
+data class LoginCommand(
     val id: String,
     val password: String,
 )

--- a/src/main/kotlin/com/srt/service/vo/SrtSession.kt
+++ b/src/main/kotlin/com/srt/service/vo/SrtSession.kt
@@ -1,0 +1,13 @@
+package com.srt.service.vo
+
+data class SrtSession(
+    var sessionId: String,
+    val wmonid: String,
+    val srail_type10: String,
+    val srail_type8: String,
+    var netFunnelKey: String? = null,
+) {
+    fun updateSessionId(sessionId: String) = apply {
+        this.sessionId = sessionId
+    }
+}

--- a/src/main/kotlin/com/srt/service/vo/SrtSessionKey.kt
+++ b/src/main/kotlin/com/srt/service/vo/SrtSessionKey.kt
@@ -1,6 +1,0 @@
-package com.srt.service.vo
-
-data class SrtSessionKey(
-    val sessionId: String,
-    val netFunnelKey: String,
-)

--- a/src/main/kotlin/com/srt/service/vo/Ticket.kt
+++ b/src/main/kotlin/com/srt/service/vo/Ticket.kt
@@ -1,0 +1,10 @@
+package com.srt.service.vo
+
+data class Ticket(
+    val trainNumber: String,
+    val departureDate: String,
+    val departureTime: String,
+    val arrivalDate: String,
+    val arrivalTime: String,
+    val canReserve: Boolean,
+)

--- a/src/main/kotlin/com/srt/share/code/SeatType.kt
+++ b/src/main/kotlin/com/srt/share/code/SeatType.kt
@@ -1,4 +1,4 @@
-package com.srt.code
+package com.srt.share.code
 
 enum class SeatType(val description: String, val code: String) {
     GENERAL("일반", "015"),

--- a/src/main/kotlin/com/srt/share/code/StationCodes.kt
+++ b/src/main/kotlin/com/srt/share/code/StationCodes.kt
@@ -1,4 +1,4 @@
-package com.srt.code
+package com.srt.share.code
 
 enum class StationCodes(val description: String, val code: String) {
     STATION_CODE_0551("수서", "0551"),

--- a/src/main/kotlin/com/srt/share/value/JsonWebToken.kt
+++ b/src/main/kotlin/com/srt/share/value/JsonWebToken.kt
@@ -1,0 +1,4 @@
+package com.srt.share.value
+
+@JvmInline
+value class JsonWebToken(val token: String)

--- a/src/main/kotlin/com/srt/share/value/NetFunnelKey.kt
+++ b/src/main/kotlin/com/srt/share/value/NetFunnelKey.kt
@@ -1,0 +1,4 @@
+package com.srt.share.value
+
+@JvmInline
+value class NetFunnelKey(val netFunnelKey: String)

--- a/src/main/kotlin/com/srt/share/value/SessionId.kt
+++ b/src/main/kotlin/com/srt/share/value/SessionId.kt
@@ -1,0 +1,4 @@
+package com.srt.share.value
+
+@JvmInline
+value class SessionId(val sessionId: String)

--- a/src/main/kotlin/com/srt/util/HttpClientUtils.kt
+++ b/src/main/kotlin/com/srt/util/HttpClientUtils.kt
@@ -1,0 +1,54 @@
+package com.srt.util
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.HttpRequest
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.post
+import io.ktor.client.statement.request
+import io.ktor.http.Cookie
+import io.ktor.http.setCookie
+
+suspend inline fun <reified T> HttpClient.requestPost(url: String, crossinline block: HttpRequestBuilder.() -> Unit = {}): PostResult<T> {
+    return this.post(url) {
+        block()
+    }.let {
+        PostResult(
+            request = it.request,
+            body = it.body(),
+            cookies = it.setCookie().map { SimpleCookie.of(it) },
+        )
+    }
+}
+
+data class PostResult<T>(
+    val request: HttpRequest,
+    val body: T,
+    val cookies: List<SimpleCookie>,
+)
+
+data class SimpleCookie(
+    val name: String,
+    val value: String,
+) {
+    companion object {
+        fun of(cookie: Cookie): SimpleCookie {
+            return SimpleCookie(
+                name = cookie.name,
+                value = cookie.value,
+            )
+        }
+    }
+}
+
+fun List<SimpleCookie>.getByName(name: String): SimpleCookie {
+    return this.first { it.name == name }
+}
+
+fun List<SimpleCookie>.getByName(name: String, predicate: (SimpleCookie) -> Boolean): SimpleCookie {
+    return this.first { it.name == name && predicate(it) }
+}
+
+fun List<SimpleCookie>.findByName(name: String): SimpleCookie? {
+    return this.firstOrNull { it.name == name }
+}

--- a/src/main/kotlin/com/srt/util/RequestUtils.kt
+++ b/src/main/kotlin/com/srt/util/RequestUtils.kt
@@ -3,6 +3,7 @@ package com.srt.util
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.memberProperties
 
+@Suppress("UNCHECKED_CAST")
 fun Any.toFormUrlEncodedString(): String {
     val memberProperties = this::class.memberProperties as Collection<KProperty1<Any, *>>
     return memberProperties


### PR DESCRIPTION
~~우선 기능 구현 후 적당한 선에서 커밋 분리 예정~~

[작업 내용]
- 티켓 리스트 조회 기능 추가
- 세션아이디가 계속 갱신되는 것을 대응하기 위해 API 응답에 갱신된 토큰 정보 추가
- 전체적인 코드 정리

[추가적으로 처리해야 하는 내용]
- 가독성 낮은 response 필드명 정리
- 각종 벨리데이션 처리
- SrtClient에서 반복적으로 헤더를 세팅하는 방식 정리
- 세션아이디가 갱신되는 타이밍 확인 및 그에 따른 처리 방식 확인
  - 진짜 바뀌는게 맞기는 한건지
  - 바뀐다면 요청을 할 때 매번 바뀌는지
  - 요청 후 어느정도의 시간이 지났을 때 만료가 되는건지
  - 진짜 만료가 되어서 오류가 발생하는게 맞는건지, 발급 후 5분만에 오류가 발생하는데 다른 이유가 있는게 아닐지
  - 앱에서는 어떻게 처리가 되고있는지
```
{"ERROR_MSG":"","ERROR_CODE":"0","resultMap":[{"msgCd":"NET000001","strResult":"FAIL","msgTxt":"서비스가 접속이 원활하지 않습니다. 잠시후 다시 시도하여 주시기 바랍니다."}],"outDataSets":{"dsOutput0":[{"msgCd":"NET000001","strResult":"FAIL","msgTxt":"서비스가 접속이 원활하지 않습니다. 잠시후 다시 시도하여 주시기 바랍니다."}]}}
```
